### PR TITLE
Add support Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: xenial
 language: python
 
 python:
+  - 3.9
   - 3.8
   - 3.7
   - 3.6

--- a/pycbrf/banks.py
+++ b/pycbrf/banks.py
@@ -14,11 +14,7 @@ from .utils import WithRequests
 LOG = getLogger(__name__)
 
 
-class _BankBase(NamedTuple):
-    """Base from banks."""
-
-
-class BankLegacy(_BankBase, NamedTuple):
+class BankLegacy(NamedTuple):
     """Represents bank entry in legacy format.
 
     Such objects will populate Banks().banks
@@ -53,7 +49,7 @@ class BankLegacy(_BankBase, NamedTuple):
     swift: Optional[str]
 
 
-class Bank(_BankBase, NamedTuple):
+class Bank(NamedTuple):
     """Represents bank entry in current format.
 
     Such objects will populate Banks().banks
@@ -217,7 +213,7 @@ class Banks(WithRequests):
                     # Some fields may be missing in Bank/BankLegacy
                     continue
 
-                if isinstance(value, _BankBase):
+                if isinstance(value, (BankLegacy, Bank)):
                     value = pick_value(value._asdict())
 
                 elif isinstance(value, bool):

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'License :: OSI Approved :: BSD License',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # See http://tox.readthedocs.org/en/latest/examples.html for samples.
 [tox]
-envlist = py{36,37,38}
+envlist = py{36,37,38,39}
 
 skip_missing_interpreters = True
 


### PR DESCRIPTION
bpo-36517: Multiple inheritance with typing.NamedTuple now raises an error instead of silently ignoring other types.